### PR TITLE
Clean up unused variables in xplat/privacy_infra

### DIFF
--- a/lib/kdf/kdf_sdhi.c
+++ b/lib/kdf/kdf_sdhi.c
@@ -59,8 +59,6 @@ static enum kdf_error derive_key_pair(
   }
 
   const unsigned char* primary_private_key_ptr = primary_key;
-  const unsigned char* primary_public_key_ptr =
-      primary_key + kdf->primary_private_key_bytes;
 
   // Hash attribute to scalar
   unsigned char attr_hash[scalar_bytes];

--- a/lib/tests/voprf_test.cpp
+++ b/lib/tests/voprf_test.cpp
@@ -81,7 +81,6 @@ struct VoprfTest
 
 TEST_P(VoprfTest, NotOnCurveTest) {
   unsigned char output_buffer[curve_.element_bytes];
-  unsigned char evaluated_element[curve_.element_bytes];
   unsigned char not_on_curve_element[curve_.element_bytes];
   unsigned char on_curve_element[curve_.element_bytes];
   unsigned char blinding_factor[curve_.scalar_bytes];
@@ -157,7 +156,6 @@ TEST_P(VoprfTest, NotOnCurveTest) {
 
 TEST_P(VoprfTest, BlindingTest) {
   unsigned char* token = (unsigned char*)"test";
-  unsigned char* token2 = (unsigned char*)"fake";
   const size_t token_len = 4;
 
   // blind


### PR DESCRIPTION
Summary: Unused variables showing up as buck2 errors. This blocks migration to buck2.

Reviewed By: aniketmathur

Differential Revision: D44643181

