### PR TITLE
Add C++ ifdefs for dApp to compile

### DIFF
--- a/lib/curve/curve_ristretto.h
+++ b/lib/curve/curve_ristretto.h
@@ -9,6 +9,10 @@
 
 #include "lib/curve/curve.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Implementation for curve ristretto.
  * Example:
@@ -19,3 +23,7 @@
  */
 
 void curve_ristretto_init(curve_t* /* curve */);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/voprf/voprf_exp_twohashdh.h
+++ b/lib/voprf/voprf_exp_twohashdh.h
@@ -9,6 +9,10 @@
 
 #include "lib/voprf/voprf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * (Double) Hashed Diffie-Hellman (two hash DH) implementations with
  * exponential blinding.
@@ -35,3 +39,7 @@
  */
 
 void voprf_exp_twohashdh_init(voprf_t* /* voprf */, curve_t* /* curve */);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Summary: I want to link these headers into the messenger desktop app in a C++ module. These ifdefs are needed to import the headers in C++.

Reviewed By: zhang00000

Differential Revision: D52298408


