### PR TITLE
Fix tautological pointer comparison issues in ../xplat/privacy_infra/anon_cred/v3/lib/tests/kdf_test.cpp

### DIFF
--- a/lib/tests/kdf_test.cpp
+++ b/lib/tests/kdf_test.cpp
@@ -172,7 +172,7 @@ TEST_P(KdfTest, ProofTest) {
           attribute_len_arr),
       KDF_SUCCESS);
 
-  if (pk_proof_len > 0 && pk_proof != NULL) {
+  if (pk_proof_len > 0) {
     // pass another attribute array, verification should fail
     EXPECT_EQ(
         kdf_.verify_public_key(


### PR DESCRIPTION
Summary:
Required for LLVM-17.

Fixes
```
      8 xplat/privacy_infra/anon_cred/v3/lib/tests/kdf_test.cpp:175:27: error: comparison of array 'pk_proof' not equal to a null pointer is always true [-Werror,-Wtautological-pointer-compare]
```

Reviewed By: palmje

Differential Revision: D56207657


